### PR TITLE
Fix test failures caused by mysql command use

### DIFF
--- a/test/endtoend/utils.sh
+++ b/test/endtoend/utils.sh
@@ -33,7 +33,10 @@ function checkKeyspaceServing() {
   ks=$1
   shard=$2
   nb_of_replica=$3
-  out=$(mysql -h 127.0.0.1 -u user --table --execute="show vitess_tablets")
+
+  # Use mariadb for now because of "mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead."
+  # And disable ssl-mode to address "ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it"
+  out=$(mariadb --ssl-mode=DISABLED -h 127.0.0.1 -u user --table --execute="show vitess_tablets")
   numtablets=$(echo "$out" | grep -E "$ks(.*)$shard(.*)PRIMARY(.*)SERVING|$ks(.*)$shard(.*)REPLICA(.*)SERVING|$ks(.*)$shard(.*)RDONLY(.*)SERVING" | wc -l)
   if [[ $numtablets -ge $((nb_of_replica+1)) ]]; then
     echo "Shard $ks/$shard is serving"


### PR DESCRIPTION
The CI suddenly failed due to `ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it` so disable ssl-mode.

- ref. https://github.com/yoheimuta/vitess-activerecord-migration/actions/runs/13192010008/job/36826553090