### PR TITLE
Expand `#wait_for_ddl` error logic

### DIFF
--- a/spec/support/rails_support.rb
+++ b/spec/support/rails_support.rb
@@ -57,6 +57,9 @@ class RailsSupport
     @migration_files.each do |f|
       FileUtils.rm(f)
     end
+
+    # Cancel any leftover Vitess migrations (otherwise subsequent tests runs might wait indefinitely for them to finish)
+    ActiveRecord::Base.connection.execute("ALTER VITESS_MIGRATION cancel all")
   end
 
   def run(command, rails_env = "test")


### PR DESCRIPTION
Closes https://github.com/yoheimuta/vitess-activerecord-migration/issues/4

@yoheimuta Based on our discussing in #4, I updated the `#wait_for_ddl` method to raise errors for failed, cancelled, or timed out migrations.  Please let me know if you have any questions, feedback, or suggestions.  I tried to document the changes with code comments, but please let me know if anything seems unclear or unusual.

Thank you for having a comprehensive test suite on this project. 🤩 It was very helpful for iterating on these changes and it  increases our overall confidence in using this gem. ✨